### PR TITLE
Fix donation link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,4 +11,4 @@ Support for a wide range of e-book formats, custom fonts and styling, profiles, 
 
 ## The author
 
-I write [books](https://dmpop.gumroad.com), and I really like [coffee]('https://www.paypal.com/paypalme/dmpop).
+I write [books](https://dmpop.gumroad.com), and I really like [coffee](https://www.paypal.com/paypalme/dmpop).


### PR DESCRIPTION
I noticed your donation link wasn't working on https://dmpop.github.io/koreader-compendium/ (at least in firefox) due to a typo. This small change should fix it.